### PR TITLE
Add `unified_mode true` to fix Chef Infra 18 deprecation warning

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'dennis.hoer@gmail.com'
 license 'MIT'
 description "Configures automatic login using a Gavin Brock's kcpassword"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.0.0'
+version '5.0.1'
 
 supports 'mac_os_x', '>= 10.7'
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 actions :enable, :disable
 default_action :enable
 


### PR DESCRIPTION
Fixes #5